### PR TITLE
feat: apply time sync and journald setters

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -139,7 +139,7 @@ fi
   if [ "$S3_PATH_PREFIX" = "none" ]; then S3_PATH_PREFIX=""; fi
 fi
 
-# Set system timezone
+# Configure host time settings and journald storage limits
 set_timezone Europe/Amsterdam
 set_time_sync
 set_journald_limits

--- a/install.sh
+++ b/install.sh
@@ -139,9 +139,11 @@ fi
   if [ "$S3_PATH_PREFIX" = "none" ]; then S3_PATH_PREFIX=""; fi
 fi
 
-# Configure host time settings and journald storage limits
+# Configure host time settings
 set_timezone Europe/Amsterdam
 set_time_sync
+
+# Configure journald storage limits
 set_journald_limits
 
 # Perform OS updates if requested by the user

--- a/install.sh
+++ b/install.sh
@@ -141,6 +141,8 @@ fi
 
 # Set system timezone
 set_timezone Europe/Amsterdam
+set_time_sync
+set_journald_limits
 
 # Perform OS updates if requested by the user
 if [ "$DO_UPDATES" == "y" ]; then


### PR DESCRIPTION
## Summary
- call `set_time_sync` during installation to enable system time synchronization where supported
- call `set_journald_limits` to apply the default journald storage limits from `bash-functions`
- use the smaller helpers merged in oszuidwest/bash-functions#15 instead of the earlier broad hardening baseline

## Validation
- `bash -n` on the modified installer script
- `shellcheck` on the modified installer script
- `git diff --check`