### PR TITLE
fix: standardize owncast installer lifecycle

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# Files to download
-FUNCTIONS_LIB_URL="https://raw.githubusercontent.com/oszuidwest/bash-functions/main/common-functions.sh"
+BASH_FUNCTIONS_REF="main"
+FUNCTIONS_LIB_URL="https://raw.githubusercontent.com/oszuidwest/bash-functions/${BASH_FUNCTIONS_REF}/common-functions.sh"
 DOCKER_COMPOSE_URL="https://raw.githubusercontent.com/oszuidwest/zwtv-owncast/main/docker-compose.yml"
 CADDYFILE_URL="https://raw.githubusercontent.com/oszuidwest/zwtv-owncast/main/Caddyfile"
 ENV_EXAMPLE_URL="https://raw.githubusercontent.com/oszuidwest/zwtv-owncast/main/.env.example"
 
-# Constants
 FUNCTIONS_LIB_PATH=$(mktemp)
 ENV_EXAMPLE_TMP=$(mktemp)
 INSTALL_DIR="/opt/owncast"
@@ -14,36 +14,80 @@ COMPOSE_FILE="${INSTALL_DIR}/docker-compose.yml"
 CADDY_FILE="${INSTALL_DIR}/Caddyfile"
 ENV_FILE="${INSTALL_DIR}/.env"
 
-# Clean up temporary files on exit
 trap 'rm -f "$FUNCTIONS_LIB_PATH" "$ENV_EXAMPLE_TMP"' EXIT
 
-# Download the functions library
-if ! curl -s -o "$FUNCTIONS_LIB_PATH" "$FUNCTIONS_LIB_URL"; then
-  echo -e "*** Failed to download functions library. Please check your network connection! ***"
+clear || true
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "*** curl is required to download the functions library. ***"
   exit 1
 fi
 
-# Source the functions file
+if ! curl -fsSL -o "$FUNCTIONS_LIB_PATH" "$FUNCTIONS_LIB_URL"; then
+  echo "*** Failed to download functions library. Please check your network connection. ***"
+  exit 1
+fi
+
 # shellcheck source=/dev/null
 source "$FUNCTIONS_LIB_PATH"
 
-# Set color variables
 set_colors
-
-# Check if the script is running as root
 assert_user_privileged "root"
-
-# Ensure the script is running on a supported platform (Linux, 64-bit)
 assert_os_linux
 assert_os_64bit
+assert_tool "curl" "docker"
 
-# Check if docker is installed
-assert_tool "docker"
+CONTAINER_NAMES=("owncast" "caddy")
 
-# Clear the terminal
-clear
+containers_running() {
+  local name
+  for name in "${CONTAINER_NAMES[@]}"; do
+    if docker ps --filter "name=^${name}$" --format '{{.Names}}' 2>/dev/null | grep -qx "$name"; then
+      return 0
+    fi
+  done
+  return 1
+}
 
-# Display Banner
+containers_exist() {
+  local name
+  for name in "${CONTAINER_NAMES[@]}"; do
+    if docker ps -a --filter "name=^${name}$" --format '{{.Names}}' 2>/dev/null | grep -qx "$name"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+stop_existing_stack() {
+  if [ -f "${COMPOSE_FILE}" ]; then
+    (cd "${INSTALL_DIR}" && docker compose down --timeout 30 --remove-orphans) || true
+  fi
+
+  local name
+  for name in "${CONTAINER_NAMES[@]}"; do
+    if docker ps -a --filter "name=^${name}$" --format '{{.Names}}' 2>/dev/null | grep -qx "$name"; then
+      docker rm -f "$name" >/dev/null 2>&1 || true
+    fi
+  done
+}
+
+verify_containers_running() {
+  sleep 3
+  local failed=0
+  local name status
+  for name in "${CONTAINER_NAMES[@]}"; do
+    status="$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo missing)"
+    if [ "$status" = "running" ]; then
+      echo -e "${GREEN}✓ ${name} is ${status}${NC}"
+    else
+      echo -e "${RED}✗ ${name} is ${status}${NC}"
+      failed=1
+    fi
+  done
+  return "$failed"
+}
+
 cat << "EOF"
  ______   _ ___ ______        _______ ____ _____   _______     __
 |__  / | | |_ _|  _ \ \      / / ____/ ___|_   _| |_   _\ \   / /
@@ -52,20 +96,16 @@ cat << "EOF"
 /____|\___/|___|____/  \_/\_/  |_____|____/ |_|     |_|    \_/
 EOF
 
-# Greet the user
 echo -e "${GREEN}⎎ Dockerized Owncast for ZuidWest TV${NC}\n\n"
 
 # Detect existing installation
 EXISTING_INSTALL="n"
-CONTAINERS_RUNNING="n"
-if [ -f "${ENV_FILE}" ] || [ -f "${COMPOSE_FILE}" ] || docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qE '^(owncast|caddy)$'; then
+if [ -f "${ENV_FILE}" ] || [ -f "${COMPOSE_FILE}" ] || containers_exist; then
   EXISTING_INSTALL="y"
   echo -e "${YELLOW}Existing installation detected.${NC}\n"
 fi
 
-# Check if containers are currently running
-if docker ps --format '{{.Names}}' 2>/dev/null | grep -qE '^(owncast|caddy)$'; then
-  CONTAINERS_RUNNING="y"
+if containers_running; then
   echo -e "${YELLOW}Owncast is currently running. Continuing will stop the stream.${NC}"
   prompt_user "CONTINUE_INSTALL" "y" "Continue with installation? (y/n)" "y/n"
   if [ "$CONTINUE_INSTALL" != "y" ]; then
@@ -75,25 +115,6 @@ if docker ps --format '{{.Names}}' 2>/dev/null | grep -qE '^(owncast|caddy)$'; t
   echo ""
 fi
 
-# Handle orphaned containers (running but no .env file)
-if [ "$CONTAINERS_RUNNING" == "y" ] && [ ! -f "${ENV_FILE}" ]; then
-  echo -e "${BLUE}►► Stopping orphaned containers before proceeding${NC}"
-  cd "${INSTALL_DIR}" 2>/dev/null || true
-  if ! docker compose down --timeout 30 2>/dev/null; then
-    echo -e "${YELLOW}  Normal shutdown failed, forcing removal${NC}"
-    docker compose down --remove-orphans --timeout 10 2>/dev/null || true
-    docker rm -f owncast caddy 2>/dev/null || true
-  fi
-  # Verify containers are stopped
-  if docker ps --format '{{.Names}}' 2>/dev/null | grep -qE '^(owncast|caddy)$'; then
-    echo -e "${RED}*** Failed to stop existing containers. Please stop them manually and try again. ***${NC}"
-    exit 1
-  fi
-  CONTAINERS_RUNNING="n"
-  echo ""
-fi
-
-# Ask for user input
 prompt_user "DO_UPDATES" "y" "Perform OS updates? (y/n)" "y/n"
 
 # Handle configuration based on existing installation
@@ -104,7 +125,6 @@ else
 fi
 
 if [ "$KEEP_CONFIG" == "n" ]; then
-  # Fresh install or user wants to reconfigure
   prompt_user "STREAM_KEY" "hackme123" "Owncast stream key" "str"
   prompt_user "ADMIN_PASSWORD" "admin123" "Owncast admin password" "str"
   prompt_user "ADMIN_IPS" "0.0.0.0/0" "IPs allowed to access Owncast admin (space-separated, 0.0.0.0/0 = allow all)" "str"
@@ -112,26 +132,26 @@ if [ "$KEEP_CONFIG" == "n" ]; then
   prompt_user "STREAM_NAME" "none" "Stream name (optional, leave empty to skip)" "str"
   prompt_user "LOGO_URL" "none" "Logo URL (optional, leave empty to skip)" "str"
   prompt_user "S3_ENDPOINT" "none" "S3 endpoint (optional, leave empty to skip S3)" "str"
-if [ "$S3_ENDPOINT" != "none" ]; then
-  prompt_user "S3_ACCESS_KEY" "" "S3 access key" "str"
-  prompt_user "S3_SECRET_KEY" "" "S3 secret key" "str"
-  prompt_user "S3_BUCKET" "" "S3 bucket name" "str"
-  prompt_user "S3_REGION" "auto" "S3 region (default: auto)" "str"
-  prompt_user "S3_ACL" "private" "S3 ACL (default: private)" "str"
-  prompt_user "S3_PATH_PREFIX" "none" "S3 path prefix (optional)" "str"
-  prompt_user "S3_FORCE_PATH_STYLE" "false" "S3 force path style (true/false, default: false)" "str"
-  prompt_user "VIDEO_SERVING_ENDPOINT" "" "Video serving endpoint (optional)" "str"
-else
-  S3_ENDPOINT=""
-  S3_ACCESS_KEY=""
-  S3_SECRET_KEY=""
-  S3_BUCKET=""
-  S3_REGION="auto"
-  S3_ACL="private"
-  S3_PATH_PREFIX=""
-  S3_FORCE_PATH_STYLE="false"
-  VIDEO_SERVING_ENDPOINT=""
-fi
+  if [ "$S3_ENDPOINT" != "none" ]; then
+    prompt_user "S3_ACCESS_KEY" "" "S3 access key" "str"
+    prompt_user "S3_SECRET_KEY" "" "S3 secret key" "str"
+    prompt_user "S3_BUCKET" "" "S3 bucket name" "str"
+    prompt_user "S3_REGION" "auto" "S3 region (default: auto)" "str"
+    prompt_user "S3_ACL" "private" "S3 ACL (default: private)" "str"
+    prompt_user "S3_PATH_PREFIX" "none" "S3 path prefix (optional)" "str"
+    prompt_user "S3_FORCE_PATH_STYLE" "false" "S3 force path style (true/false, default: false)" "str"
+    prompt_user "VIDEO_SERVING_ENDPOINT" "" "Video serving endpoint (optional)" "str"
+  else
+    S3_ENDPOINT=""
+    S3_ACCESS_KEY=""
+    S3_SECRET_KEY=""
+    S3_BUCKET=""
+    S3_REGION="auto"
+    S3_ACL="private"
+    S3_PATH_PREFIX=""
+    S3_FORCE_PATH_STYLE="false"
+    VIDEO_SERVING_ENDPOINT=""
+  fi
 
   # Convert 'none' to empty strings for optional fields
   if [ "$STREAM_NAME" = "none" ]; then STREAM_NAME=""; fi
@@ -146,34 +166,29 @@ set_time_sync
 # Configure journald storage limits
 set_journald_limits
 
-# Perform OS updates if requested by the user
 if [ "$DO_UPDATES" == "y" ]; then
   apt_update --silent
 fi
 
-# Create the installation directory
 echo -e "${BLUE}►► Creating installation directory: ${INSTALL_DIR}${NC}"
 mkdir -p "${INSTALL_DIR}"
 
-# Download docker-compose.yml
 echo -e "${BLUE}►► Downloading docker-compose.yml${NC}"
-if ! curl -s -o "${COMPOSE_FILE}" "${DOCKER_COMPOSE_URL}"; then
-  echo -e "${RED}*** Failed to download docker-compose.yml. Please check your network connection! ***${NC}"
+if ! file_download "${DOCKER_COMPOSE_URL}" "${COMPOSE_FILE}" "docker-compose.yml" --backup; then
   exit 1
 fi
 
-# Download Caddyfile
 echo -e "${BLUE}►► Downloading Caddyfile${NC}"
-if ! curl -s -o "${CADDY_FILE}" "${CADDYFILE_URL}"; then
-  echo -e "${RED}*** Failed to download Caddyfile. Please check your network connection! ***${NC}"
+if ! file_download "${CADDYFILE_URL}" "${CADDY_FILE}" "Caddyfile" --backup; then
   exit 1
 fi
 
-# Handle .env file
 if [ "$KEEP_CONFIG" == "y" ]; then
-  # Download .env.example to temp location for merging new variables
   echo -e "${BLUE}►► Checking for new configuration variables${NC}"
-  if curl -s -o "${ENV_EXAMPLE_TMP}" "${ENV_EXAMPLE_URL}"; then
+  if curl -fsSL -o "${ENV_EXAMPLE_TMP}" "${ENV_EXAMPLE_URL}"; then
+    if ! file_backup "${ENV_FILE}"; then
+      exit 1
+    fi
     # Add any new variables from .env.example that don't exist in current .env
     while IFS= read -r line; do
       # Skip comments and empty lines
@@ -188,14 +203,11 @@ if [ "$KEEP_CONFIG" == "y" ]; then
     done < "${ENV_EXAMPLE_TMP}"
   fi
 else
-  # Fresh install: download and configure .env
   echo -e "${BLUE}►► Downloading .env.example and renaming it to .env${NC}"
-  if ! curl -s -o "${ENV_FILE}" "${ENV_EXAMPLE_URL}"; then
-    echo -e "${RED}*** Failed to download .env.example. Please check your network connection! ***${NC}"
+  if ! file_download "${ENV_EXAMPLE_URL}" "${ENV_FILE}" ".env.example" --backup; then
     exit 1
   fi
 
-  # Fill in the .env file with user-provided values
   echo -e "${BLUE}►► Filling in the .env file with provided values${NC}"
   sed -i "s|ADMIN_PASSWORD=.*|ADMIN_PASSWORD=\"${ADMIN_PASSWORD}\"|g" "${ENV_FILE}"
   sed -i "s|ADMIN_IPS=.*|ADMIN_IPS=\"${ADMIN_IPS}\"|g" "${ENV_FILE}"
@@ -222,7 +234,6 @@ fi
 # Restrict permissions on .env file (contains credentials)
 chmod 600 "${ENV_FILE}"
 
-# Instructions for next steps
 echo -e "\n\n${GREEN}✓ Installation set up at ${INSTALL_DIR}${NC}"
 if [ "$KEEP_CONFIG" == "y" ]; then
   echo -e "${YELLOW}Existing configuration has been preserved.${NC}"
@@ -230,48 +241,35 @@ else
   echo -e "${YELLOW}The .env file has been populated with the values you provided.${NC}"
 fi
 
-# Start Owncast and Caddy
 prompt_user "START_OWNCAST" "y" "Start Owncast and Caddy now? (y/n)" "y/n"
 if [ "$START_OWNCAST" == "y" ]; then
   cd "${INSTALL_DIR}" || exit
 
-  # Stop existing containers if running (handles upgrades)
-  if docker compose ps -q 2>/dev/null | grep -q . || docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qE '^(owncast|caddy)$'; then
+  echo -e "${BLUE}►► Validating Docker Compose configuration${NC}"
+  docker compose config -q
+
+  if [ "$EXISTING_INSTALL" == "y" ] || containers_exist; then
     echo -e "${BLUE}►► Stopping existing containers${NC}"
-    if ! docker compose down --timeout 30 2>/dev/null; then
-      echo -e "${YELLOW}  Normal shutdown failed, forcing removal${NC}"
-      docker compose down --remove-orphans --timeout 10 2>/dev/null || true
-      docker rm -f owncast caddy 2>/dev/null || true
-    fi
-    # Verify containers are stopped
-    if docker ps --format '{{.Names}}' 2>/dev/null | grep -qE '^(owncast|caddy)$'; then
-      echo -e "${RED}*** Failed to stop existing containers. Please stop them manually and try again. ***${NC}"
-      exit 1
-    fi
+    stop_existing_stack
   fi
 
-  # Pull fresh images
   echo -e "${BLUE}►► Pulling latest images${NC}"
   docker compose pull
 
-  # Start containers
   echo -e "${BLUE}►► Starting containers${NC}"
   docker compose up -d
 
-  # Verify containers are running
-  echo -e "${BLUE}►► Verifying containers${NC}"
-  sleep 3
-  if docker compose ps --format '{{.Name}} {{.Status}}' | grep -q "Up"; then
-    echo -e "${GREEN}✓ Containers are running${NC}"
+  echo -e "${BLUE}►► Checking container runtime state${NC}"
+  if ! verify_containers_running; then
+    echo -e "${RED}*** Some containers are not running. Check 'docker compose logs'. ***${NC}"
     docker compose ps
-  else
-    echo -e "${RED}*** Warning: Some containers may not be running properly ***${NC}"
-    docker compose ps
+    exit 1
   fi
+  echo -e "${GREEN}✓ All containers are running${NC}"
+  docker compose ps
 
   prompt_user "RUN_POSTINSTALL" "y" "Run the postinstall script? (y/n)" "y/n"
 
-  # Run the postinstall script if requested by the user
   if [ "$RUN_POSTINSTALL" == "y" ]; then
     echo -e "${BLUE}►► Running postinstall script${NC}"
     docker run --rm \


### PR DESCRIPTION
## Summary
- Make the bash-functions ref explicit as `main` and standardize bootstrap failure handling.
- Enable strict mode after fixing optional branches and container detection.
- Use shared download/backup handling for managed files, validate Compose before start, and require both containers to be running.

## Validation
- `bash -n install.sh`
- `shellcheck install.sh`
- `git diff --check HEAD~1..HEAD`
- Debian container: missing curl bootstrap path
- Debian container: missing Docker prerequisite path

## Host Test Note
- Docker-capable host rerun with existing `.env` and postinstall path still required before merge.